### PR TITLE
Adding config option to toggle zprint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,71 +1,91 @@
 version: 2
 
-docker_defaults: &docker_defaults
+docker-defaults: &docker-defaults
   docker:
-    - image: 191234350269.dkr.ecr.us-east-1.amazonaws.com/circleci-build:1.3
+    - image: 191234350269.dkr.ecr.us-east-1.amazonaws.com/circleci-build:1.4
       environment:
         JAVA_OPTS: "-Xms512m -Xmx3200m"
         LEIN_ROOT: nbd
 
-restore_anchor: &restore_anchor
+restore-anchor: &restore-anchor
   restore_cache:
-    key: workframe-catchpocket-{{ checksum "project.clj" }}
+    key: workframe-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ checksum "project.clj" }}
 
 jobs:
   dependencies:
-    <<: *docker_defaults
+    <<: *docker-defaults
     steps:
       - checkout
-      - <<: *restore_anchor
-      - run: lein with-profile +test deps
+      - <<: *restore-anchor
+      - run: lein with-profile +test,+docs deps
       - run: lein jar
       - save_cache:
-          key: workframe-catchpocket-{{ checksum "project.clj" }}
+          key: workframe-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ checksum "project.clj" }}
           paths:
             - ~/.m2
             - target
   tests:
-    <<: *docker_defaults
+    <<: *docker-defaults
     steps:
       - checkout
-      - <<: *restore_anchor
+      - <<: *restore-anchor
       - run: lein with-profile +test cloverage -s test --junit
       - store_test_results:
           path: target/coverage
       - store_artifacts:
           path: target/coverage
   docs:
-    <<: *docker_defaults
+    <<: *docker-defaults
     steps:
       - checkout
-      - <<: *restore_anchor
+      - <<: *restore-anchor
       - run: lein with-profile +docs codox
       - run: lein with-profile +docs asciidoctor
       - store_artifacts:
           path: target/doc
           path: target/manual
   slides:
-    <<: *docker_defaults
+    <<: *docker-defaults
     working_directory: ~/project/docs/slides
     steps:
       - checkout
-      - <<: *restore_anchor
+      - <<: *restore-anchor
       - run: mkdir -p ../../target/slides
       - run: npm i
       - run: node ./build.js
       - store_artifacts:
           path: target/slides
-  deploy:
-    <<: *docker_defaults
+  s3-deploy:
+    <<: *docker-defaults
     steps:
       - checkout
-      - <<: *restore_anchor
+      - <<: *restore-anchor
       - run:
           name: Compile jar
           command: lein install
       - deploy:
           name: Deploy to S3
           command: lein deploy workframe-private
+  clojars-push:
+    <<: *docker-defaults
+    steps:
+      - checkout
+      - <<: *restore-anchor
+      - run:
+          name: Compile jar
+          command: lein install
+      - deploy:
+          name: Deploy to Clojars
+          command: lein deploy clojars
+  doc-deploy:
+    <<: *docker-defaults
+    working_directory: ~/project/docs
+    steps:
+      - checkout
+      - <<: *restore-anchor
+      - deploy:
+          name: Deploy docs
+          command: ./deploy.sh
 
 workflows:
   version: 2
@@ -73,45 +93,32 @@ workflows:
     jobs:
       - dependencies:
           filters:
-            tags:
-              only: /.*/
+            tags: { only: /.*/ }
       - tests:
           requires:
             - dependencies
           filters:
-            tags:
-              only: /.*/
+            tags: { only: /.*/ }
       - docs:
           requires:
             - dependencies
-          filters:
-            tags:
-              only: /^catchpocket-.*/, /docs.*/
-            branches:
-              ignore: /.*/
       - slides:
           requires:
             - dependencies
           filters:
-            tags:
-              only: /^catchpocket-.*/, /docs.*/
-            branches:
-              ignore: /.*/
+            tags: { only: [ /^catchpocket-.*/, /docs-.*/ ] }
+            branches: { ignore: /.*/ }
       - doc-deploy:
           requires:
             - docs
             - slides
           filters:
-            tags:
-              only: /^catchpocket-.*/, /docs.*/
-            branches:
-              ignore: /.*/
+            tags: { only: [ /^catchpocket-.*/, /docs-.*/ ] }
+            branches: { ignore: /.*/ }
       # Only deploy stuff that is tagged
-      - deploy:
+      - s3-deploy:
           requires:
             - tests
           filters:
-            tags:
-              only: /^catchpocket-.*/
-            branches:
-              ignore: /.*/
+            tags: { only: [ /^catchpocket-.*/ ] }
+            branches: { ignore: /.*/ }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-## [0.1.0] - 2018-02-08
-### Added
+## [0.6.0] - 2018-04-18
 
-- Initial release
+- Initial public release

--- a/project.clj
+++ b/project.clj
@@ -6,13 +6,12 @@
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
 
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/tools.cli "0.3.5"]
-                 [com.workframe/stillsuit "0.7.0"]
-                 [fipp "0.6.12"]
-                 [zprint "0.4.7"]
+                 [org.clojure/tools.cli "0.3.7"]
+                 [com.workframe/stillsuit "0.12.0"]
+                 [zprint "0.4.9"]
                  [funcool/cuerdas "2.0.5"]
                  [com.datomic/datomic-pro "0.9.5656" :scope "provided"]
-                 [org.clojure/tools.logging "0.4.0"]
+                 [org.clojure/tools.logging "0.4.1"]
                  [org.apache.logging.log4j/log4j-core "2.11.0"]
                  [org.apache.logging.log4j/log4j-slf4j-impl "2.11.0"]]
 
@@ -24,7 +23,7 @@
 
   :aot [catchpocket.main]
 
-  :plugins [[s3-wagon-private "1.3.1" :exclusions [commons-logging]]]
+  :plugins [[s3-wagon-private "1.3.2" :exclusions [commons-logging]]]
 
   :repositories [["workframe-private"
                   {:url           "s3p://deployment.workframe.com/maven/releases/"
@@ -44,20 +43,21 @@
   :aliases {"refresh" ["with-profile" "+ultra" "test-refresh"]
             "preview" ["with-profile" "+test" "run" "-m" "catchpocket.preview"]}
 
-  :profiles {:dev     {:plugins      [[s3-wagon-private "1.3.1" :exclusions [commons-logging]]
-                                      [jonase/eastwood "0.2.5"]
+  :profiles {:dev     {:plugins      [[jonase/eastwood "0.2.6"]
                                       [com.jakemccrary/lein-test-refresh "0.22.0"]
                                       [lein-cloverage "1.0.10"]
                                       [lein-codox "0.10.3"]
                                       [lein-shell "0.5.0"]]
                        :dependencies [[codox-theme-rdash "0.1.2"]
-                                      [com.walmartlabs/lacinia-pedestal "0.7.0"]
-                                      [io.forward/yaml "1.0.7" :exclusions [org.flatland/ordered]]]}
+                                      [com.walmartlabs/lacinia-pedestal "0.8.0"
+                                       :exclusions [com.walmartlabs/lacinia]]
+                                      [io.forward/yaml "1.0.8" :exclusions [org.flatland/ordered]]]}
              :docs    {:plugins      [[lein-codox "0.10.3"]
-                                      [lein-asciidoctor "0.1.15" :exclusions [org.slf4j/slf4j-api]]]
+                                      [lein-asciidoctor "0.1.16" :exclusions [org.slf4j/slf4j-api]]]
                        :dependencies [[codox-theme-rdash "0.1.2"]]}
              :ancient {:plugins [[lein-ancient "0.6.15"
                                   :exclusions [commons-logging
+                                               org.apache.httpcomponents/httpclient
                                                com.fasterxml.jackson.core/jackson-annotations
                                                com.fasterxml.jackson.core/jackson-core
                                                com.fasterxml.jackson.core/jackson-databind]]]}

--- a/resources/catchpocket/defaults.edn
+++ b/resources/catchpocket/defaults.edn
@@ -1,5 +1,6 @@
 ;; This is the base catchpocket file, which can be overridden by the one specified on the command-line
 {:catchpocket/version           "0.1"
  :catchpocket/schema-file       "target/catchpocket/schema.edn"
+ :catchpocket/zprint?           true
  :stillsuit/db-id-name          :dbId
  :stillsuit/datomic-entity-type :DatomicEntity}

--- a/src/catchpocket/generate/core.clj
+++ b/src/catchpocket/generate/core.clj
@@ -5,7 +5,6 @@
             [catchpocket.generate.enums :as enums]
             [clojure.tools.logging :as log]
             [clojure.java.io :as io]
-            [fipp.edn :as fipp]
             [zprint.core :as zp]
             [catchpocket.lib.util :as util]
             [stillsuit.lib.util :as su]
@@ -209,16 +208,19 @@
         schema   (queries/attach-queries objects ent-map config)]
     schema))
 
-(def zprint-config {:map {:comma?   false
-                          :sort?    true
-                          :indent   0
-                          :justify? true}})
+(def default-zprint-config {:map {:comma?   false
+                                  :sort?    true
+                                  :indent   0
+                                  :justify? true}})
+(def zprint-width 120)
 
-(defn- write-file! [schema config]
-  (let [filename (:catchpocket/schema-file config)]
-    (io/make-parents filename)
-    (log/infof "Saving schema to %s..." filename)
-    (spit filename (zp/zprint-str schema 120 zprint-config))))
+(defn- write-file! [schema {:catchpocket/keys [schema-file zprint? zprint-config]}]
+  (let [content   (if zprint?
+                    (zp/zprint-str schema zprint-width (or zprint-config default-zprint-config))
+                    (pr-str schema))]
+    (io/make-parents schema-file)
+    (log/infof "Saving schema to %s..." schema-file)
+    (spit schema-file content)))
 
 (defn generate-and-write! [{:keys [:catchpocket/datomic-uri] :as config}]
   (log/infof "Connecting to %s..." datomic-uri)


### PR DESCRIPTION
zprint is an awesome pretty-printer for EDN files but it can get pretty slow once its input starts getting large. This PR adds a catchpocket config option to skip zprint formatting and just use `(pr-str)` to output results, and an option to pass in formatting configuration parameters to zprint.

I've also bumped some dependencies and cleaned up the circle.yml config somewhat.